### PR TITLE
Add name is main to prevent application from running when imported

### DIFF
--- a/SIOL.py
+++ b/SIOL.py
@@ -1,7 +1,7 @@
 import sys
 import os 
 import shutil
-version = "Standard Input-Output Language V0.1-ALPHA"
+version = "Standard Input-Output Language V0.2-ALPHA"
 keywords = ['quit', 'query', '--version']
 ACTIVE_FILE = None
 ACTIVE_PATH = os.getcwd()
@@ -336,5 +336,5 @@ def main():
 	query = input("prompt>> ")
 	transact(query) 
 	main()
-
-main()
+if __name__= '__main__':
+	main()


### PR DESCRIPTION
Prevent running main method when the application is not run but rather, for example imported into another python program